### PR TITLE
feat: add defaultRepo config for multi-repo support

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,6 +237,12 @@
     "configuration": {
       "title": "GitHub Projects",
       "properties": {
+        "ghProjects.defaultRepo": {
+          "type": "string",
+          "default": "",
+          "description": "Default repository to use (owner/name format, e.g., 'myorg/myrepo'). When set, the extension will use this repo instead of detecting from git. Useful for multi-repo projects.",
+          "pattern": "^$|^[\\w.-]+/[\\w.-]+$"
+        },
         "ghProjects.showOnlyAssignedToMe": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
## Summary
- Add `ghProjects.defaultRepo` config setting (owner/name format)
- Add `resolveTargetRepo()` helper: config setting > git detection
- Auto-reload projects when defaultRepo config changes

## Config
In VS Code settings:
```json
{
  "ghProjects.defaultRepo": "owner/repo"
}
```

## Test plan
- [ ] Test with `defaultRepo` set - should load that repo's projects
- [ ] Test without `defaultRepo` - should detect from git as before
- [ ] Test changing `defaultRepo` - should reload projects automatically
- [ ] Test invalid format - should warn and fall back to detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)