### PR TITLE
feat: add issue metadata fields to create issue form

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export interface NormalizedProjectItem {
     state: 'open' | 'closed' | 'merged' | null;
     fields: Map<string, import('@bretwardjames/ghp-core').FieldInfo>;
     issueType: string | null;
+    projectId: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add "Additional Options" expandable section in new issue form
- Support labels, assignees, issue type, and initial status on issue creation
- Add `setFieldValue()` API method for setting project field values
- Update `getProjectFields()` to include field type information

## Dependencies
- Requires `feature/multi-repo` branch (PR #6)
- Works with ghp-core `feature/issue-metadata` (PR #13)

## Test plan
- [ ] Create issue with labels - labels are applied
- [ ] Create issue with assignees - users are assigned
- [ ] Create issue with initial status - status is set in project
- [ ] Verify "Additional Options" section is collapsible

🤖 Generated with [Claude Code](https://claude.com/claude-code)